### PR TITLE
build: add quality tooling (Spotless, Checkstyle, JaCoCo) non-blocking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,9 @@ import org.gradle.language.jvm.tasks.ProcessResources
 
 plugins {
     java
+    checkstyle
+    jacoco
+    id("com.diffplug.spotless") version "6.25.0"
 }
 
 group = "me.spighetto"
@@ -62,4 +65,36 @@ tasks.named<Jar>("jar") {
     from("v1_11/target/classes") { include("me/**") }
     from("v1_13/target/classes") { include("me/**") }
     from("v1_19_4/target/classes") { include("me/**") }
+}
+
+// ----------------------
+// Quality tooling
+// ----------------------
+spotless {
+    java {
+        googleJavaFormat("1.17.0")
+        target(
+            "MyPoopPlugin/src/**/*.java"
+        )
+    }
+    kotlinGradle {
+        ktlint("1.2.1")
+        target("**/*.gradle.kts")
+    }
+}
+
+checkstyle {
+    toolVersion = "10.12.4"
+    configFile = file("config/checkstyle/checkstyle.xml")
+    isIgnoreFailures = true // non bloccante all'inizio
+}
+
+jacoco {
+    toolVersion = "0.8.10"
+}
+
+// Non bloccare la build iniziale con Spotless
+// Disabilita tutti i task di verifica Spotless (es. spotlessJavaCheck)
+tasks.matching { it.name.startsWith("spotless") && it.name.endsWith("Check") }.configureEach {
+    enabled = false
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <property name="severity" value="warning"/>
+
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="NewlineAtEndOfFile"/>
+
+    <module name="TreeWalker">
+        <module name="EmptyBlock"/>
+    </module>
+</module>
+

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -17,4 +17,13 @@ Questo file traccia le decisioni architetturali e di processo prese durante il r
 - Packaging provvisorio: include classi locali dei moduli version (target/classes) senza introdurre Shadow.
 - Rischi: differenze runtime Java; mitigazione: nessuna rimozione di Maven, verifica manuale del jar.
 
+---
+
+## 2025-09-10: Strumenti di qualità iniziali (non bloccanti)
+- Aggiunti Spotless, Checkstyle, JaCoCo.
+- Spotless enforcement disabilitato inizialmente (si userà spotlessApply manuale).
+- Checkstyle attivo con ignoreFailures=true; regole minime (tab, newline EOF).
+- JaCoCo configurato senza soglie (coverage report in seguito).
+- Obiettivo: introdurre standard senza rompere la build.
+
 Aggiungere nuove decisioni in ordine cronologico.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,6 +14,7 @@ Tracciamento delle metriche di qualità e avanzamento refactor.
 - Comando > 40 righe: TBD
 - Dipendenze Bukkit nel core: N/A (core non creato)
 - Build: Gradle single-module bootstrap DONE (2025-09-10), toolchain Java 17, Maven ancora funzionante
+- Quality: Spotless/Checkstyle/JaCoCo introdotti (2025-09-10), enforcement limitato (non bloccanti)
 
 ---
 

--- a/docs/refactor-checklist.md
+++ b/docs/refactor-checklist.md
@@ -12,13 +12,11 @@ Checklist viva per il refactor incrementale.
   - [x] Espansione versione in plugin.yml (processResources)
   - [x] Build Gradle verde in parallelo a Maven
   - [ ] Valutare packaging/shading (rimandato a Shadow plugin in step successivi)
-  - [x] Gradle wrapper
-  - [x] settings.gradle.kts
-  - [x] build.gradle.kts (collega MyPoopPlugin src e resources)
-  - [x] Espansione versione in plugin.yml (processResources)
-  - [x] Build Gradle verde in parallelo a Maven
-  - [ ] Valutare packaging/shading (rimandato a Shadow plugin in step successivi)
 - [ ] Tool qualità: Spotless, Checkstyle, JaCoCo
+  - [x] Aggiunto Spotless (enforcement disabilitato inizialmente)
+  - [x] Aggiunto Checkstyle (ignoreFailures=true)
+  - [x] Aggiunto JaCoCo (baseline, senza soglie)
+  - [ ] Abilitare enforcement Spotless/Checkstyle gradualmente
 - [ ] Multi-modulo: `mypoop-core`, `mypoop-plugin`
 - [ ] Estrarre primo servizio di dominio + primo test
 - [ ] Definire porte e adapter minimi


### PR DESCRIPTION
This pull request introduces initial code quality tools to the project, aiming to establish basic standards without disrupting the build process. The main additions are Spotless, Checkstyle, and JaCoCo, all configured in a non-blocking manner. Documentation has also been updated to reflect these decisions and the current status of quality enforcement.

**Code Quality Tooling:**

* Added a minimal `checkstyle.xml` configuration to `config/checkstyle/checkstyle.xml`, enforcing tab character and newline at end of file rules.
* Updated the refactor checklist in `docs/refactor-checklist.md` to include the addition of Spotless (with enforcement initially disabled), Checkstyle (ignoreFailures=true), and JaCoCo (baseline, no coverage thresholds).

**Documentation Updates:**

* Added a new architectural decision log entry in `docs/decision-log.md` detailing the introduction and configuration of Spotless, Checkstyle, and JaCoCo, and clarifying that these tools are not currently blocking the build.
* Updated quality metrics in `docs/metrics.md` to note the introduction of Spotless, Checkstyle, and JaCoCo, with limited enforcement.