### PR TITLE
feat(build/docs): Gradle multi-module + Paper-first plan; introduce VersionCapabilities; repo hygiene

### DIFF
--- a/MyPoopPlugin/src/main/java/me/spighetto/events/playerevents/PlayerEvents.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/events/playerevents/PlayerEvents.java
@@ -2,6 +2,7 @@ package me.spighetto.events.playerevents;
 
 import me.spighetto.events.fertilizerevent.Fertilizer;
 import me.spighetto.mypoop.MyPoop;
+import me.spighetto.mypoop.core.port.PlayerMessagingPort;
 import me.spighetto.mypoopversionsinterfaces.IMessages;
 import me.spighetto.mypoopversionsinterfaces.IPoop;
 import org.bukkit.ChatColor;
@@ -19,9 +20,11 @@ import java.lang.reflect.Constructor;
 
 public class PlayerEvents implements Listener {
     private final MyPoop plugin;
+    private final PlayerMessagingPort messagingPort;
 
-    public PlayerEvents(MyPoop plugin){
+    public PlayerEvents(MyPoop plugin, PlayerMessagingPort messagingPort){
         this.plugin = plugin;
+        this.messagingPort = messagingPort;
     }
 
     @EventHandler
@@ -96,7 +99,8 @@ public class PlayerEvents implements Listener {
     public void printMessage(Player player, String msg) {
         IMessages message = createMessagesForVersion(player, msg);
         if (message == null) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', msg));
+            // Usa la porta di messaggistica come fallback
+            messagingPort.sendTo(player.getUniqueId(), ChatColor.translateAlternateColorCodes('&', msg));
             return;
         }
 
@@ -111,7 +115,7 @@ public class PlayerEvents implements Listener {
                 message.printActionBar();
                 break;
             default:
-                player.sendMessage(ChatColor.translateAlternateColorCodes('&', msg));
+                messagingPort.sendTo(player.getUniqueId(), ChatColor.translateAlternateColorCodes('&', msg));
                 break;
         }
     }

--- a/MyPoopPlugin/src/main/java/me/spighetto/mypoop/MyPoop.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/mypoop/MyPoop.java
@@ -18,6 +18,7 @@ import me.spighetto.mypoop.adapter.config.BukkitConfigAdapter;
 import me.spighetto.mypoop.core.port.PlayerMessagingPort;
 import me.spighetto.mypoop.core.port.LoggingPort;
 import me.spighetto.mypoop.core.port.ConfigPort;
+import me.spighetto.mypoop.version.VersionCapabilities;
 
 public final class MyPoop extends JavaPlugin {
     public Map<UUID, Integer> playersLevelFood = new HashMap<>();
@@ -30,6 +31,9 @@ public final class MyPoop extends JavaPlugin {
     private LoggingPort loggingPort;
     private ConfigPort configPort;
 
+    // Version capabilities (infrastructure)
+    private VersionCapabilities versionCapabilities;
+
     @Override
     public void onEnable() {
         serverVersion = parseVersion();
@@ -38,6 +42,7 @@ public final class MyPoop extends JavaPlugin {
         this.messagingPort = new BukkitPlayerMessagingAdapter();
         this.loggingPort = new BukkitLoggingAdapter(getLogger());
         this.configPort = new BukkitConfigAdapter(getConfig());
+        this.versionCapabilities = new VersionCapabilities(serverVersion);
 
         if(!isCompatibleVersion()){
             Bukkit.getConsoleSender().sendMessage("MyPoop: Error: incompatible server version");
@@ -45,7 +50,7 @@ public final class MyPoop extends JavaPlugin {
 
         saveDefaultConfig();
         readConfigs();
-        super.getServer().getPluginManager().registerEvents(new PlayerEvents(this, messagingPort), this);
+        super.getServer().getPluginManager().registerEvents(new PlayerEvents(this, messagingPort, versionCapabilities), this);
         new Metrics(this, 8159);
 
         Objects.requireNonNull(getCommand("mypoop")).setExecutor(new Reload(this));

--- a/MyPoopPlugin/src/main/java/me/spighetto/mypoop/MyPoop.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/mypoop/MyPoop.java
@@ -12,6 +12,12 @@ import org.bukkit.entity.Entity;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.*;
+import me.spighetto.mypoop.adapter.messaging.BukkitPlayerMessagingAdapter;
+import me.spighetto.mypoop.adapter.logging.BukkitLoggingAdapter;
+import me.spighetto.mypoop.adapter.config.BukkitConfigAdapter;
+import me.spighetto.mypoop.core.port.PlayerMessagingPort;
+import me.spighetto.mypoop.core.port.LoggingPort;
+import me.spighetto.mypoop.core.port.ConfigPort;
 
 public final class MyPoop extends JavaPlugin {
     public Map<UUID, Integer> playersLevelFood = new HashMap<>();
@@ -19,9 +25,19 @@ public final class MyPoop extends JavaPlugin {
     public ArrayList<UUID> listPoops = new ArrayList<>();
     public int serverVersion;
 
+    // Porte/adapters
+    private PlayerMessagingPort messagingPort;
+    private LoggingPort loggingPort;
+    private ConfigPort configPort;
+
     @Override
     public void onEnable() {
         serverVersion = parseVersion();
+
+        // Wiring adapters
+        this.messagingPort = new BukkitPlayerMessagingAdapter();
+        this.loggingPort = new BukkitLoggingAdapter(getLogger());
+        this.configPort = new BukkitConfigAdapter(getConfig());
 
         if(!isCompatibleVersion()){
             Bukkit.getConsoleSender().sendMessage("MyPoop: Error: incompatible server version");
@@ -29,7 +45,7 @@ public final class MyPoop extends JavaPlugin {
 
         saveDefaultConfig();
         readConfigs();
-        super.getServer().getPluginManager().registerEvents(new PlayerEvents(this), this);
+        super.getServer().getPluginManager().registerEvents(new PlayerEvents(this, messagingPort), this);
         new Metrics(this, 8159);
 
         Objects.requireNonNull(getCommand("mypoop")).setExecutor(new Reload(this));

--- a/MyPoopPlugin/src/main/java/me/spighetto/mypoop/adapter/config/BukkitConfigAdapter.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/mypoop/adapter/config/BukkitConfigAdapter.java
@@ -1,0 +1,39 @@
+package me.spighetto.mypoop.adapter.config;
+
+import java.util.Optional;
+import me.spighetto.mypoop.core.port.ConfigPort;
+import org.bukkit.configuration.file.FileConfiguration;
+
+public final class BukkitConfigAdapter implements ConfigPort {
+    private final FileConfiguration cfg;
+
+    public BukkitConfigAdapter(FileConfiguration cfg) {
+        this.cfg = cfg;
+    }
+
+    @Override
+    public Optional<String> getString(String path) {
+        return Optional.ofNullable(cfg.getString(path));
+    }
+
+    @Override
+    public Optional<Boolean> getBoolean(String path) {
+        return Optional.ofNullable(cfg.get(path) instanceof Boolean ? cfg.getBoolean(path) : null);
+    }
+
+    @Override
+    public Optional<Integer> getInt(String path) {
+        return Optional.ofNullable(cfg.get(path) instanceof Number ? cfg.getInt(path) : null);
+    }
+
+    @Override
+    public Optional<Long> getLong(String path) {
+        return Optional.ofNullable(cfg.get(path) instanceof Number ? cfg.getLong(path) : null);
+    }
+
+    @Override
+    public Optional<Double> getDouble(String path) {
+        return Optional.ofNullable(cfg.get(path) instanceof Number ? cfg.getDouble(path) : null);
+    }
+}
+

--- a/MyPoopPlugin/src/main/java/me/spighetto/mypoop/adapter/logging/BukkitLoggingAdapter.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/mypoop/adapter/logging/BukkitLoggingAdapter.java
@@ -1,0 +1,32 @@
+package me.spighetto.mypoop.adapter.logging;
+
+import java.util.logging.Logger;
+import me.spighetto.mypoop.core.port.LoggingPort;
+
+public final class BukkitLoggingAdapter implements LoggingPort {
+    private final Logger logger;
+
+    public BukkitLoggingAdapter(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    @Override
+    public void warn(String message) {
+        logger.warning(message);
+    }
+
+    @Override
+    public void error(String message, Throwable t) {
+        if (t != null) {
+            logger.severe(message + " :: " + t.getMessage());
+        } else {
+            logger.severe(message);
+        }
+    }
+}
+

--- a/MyPoopPlugin/src/main/java/me/spighetto/mypoop/adapter/messaging/BukkitPlayerMessagingAdapter.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/mypoop/adapter/messaging/BukkitPlayerMessagingAdapter.java
@@ -1,0 +1,23 @@
+package me.spighetto.mypoop.adapter.messaging;
+
+import java.util.UUID;
+import me.spighetto.mypoop.core.port.PlayerMessagingPort;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * Bukkit adapter implementing PlayerMessagingPort.
+ */
+public final class BukkitPlayerMessagingAdapter implements PlayerMessagingPort {
+    @Override
+    public void sendTo(UUID playerId, String message) {
+        if (playerId == null || message == null || message.isEmpty()) {
+            return;
+        }
+        final Player player = Bukkit.getPlayer(playerId);
+        if (player != null) {
+            player.sendMessage(message);
+        }
+    }
+}
+

--- a/MyPoopPlugin/src/main/java/me/spighetto/mypoop/version/VersionCapabilities.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/mypoop/version/VersionCapabilities.java
@@ -1,0 +1,39 @@
+package me.spighetto.mypoop.version;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+/**
+ * Centralizza le differenze tra versioni Paper/Spigot per messaggistica base,
+ * evitando NMS e riducendo l'uso di reflection. Nessuna dipendenza extra.
+ */
+public final class VersionCapabilities {
+    private final int serverVersionMinor; // es: 19 per 1.19.x, 20 per 1.20.x, 21 per 1.21.x
+
+    public VersionCapabilities(int serverVersionMinor) {
+        this.serverVersionMinor = serverVersionMinor;
+    }
+
+    public boolean supportsTitles() {
+        // Le API per i titles sono stabili da anni; consideriamo sicuro da 1.11+
+        return serverVersionMinor >= 11;
+    }
+
+    public boolean supportsActionBar() {
+        // Evitiamo per ora: senza Adventure o bungeecord-chat dip, restiamo su fallback.
+        return false;
+    }
+
+    public void sendTitle(Player player, String title) {
+        // Durate conservative
+        player.sendTitle(colorize(title), "", 10, 40, 10);
+    }
+
+    public void sendSubtitle(Player player, String subtitle) {
+        player.sendTitle("", colorize(subtitle), 10, 40, 10);
+    }
+
+    public String colorize(String input) {
+        return ChatColor.translateAlternateColorCodes('&', input);
+    }
+}

--- a/docs/adr/adr-001-hexagonal-architecture.md
+++ b/docs/adr/adr-001-hexagonal-architecture.md
@@ -1,0 +1,20 @@
+# ADR 001: Adopt Hexagonal Architecture (Ports & Adapters)
+
+## Status
+Accepted
+
+## Context
+The project started as a monolithic Bukkit plugin. We want to refactor towards a testable, modular design that separates domain logic from infrastructure concerns (Bukkit/Paper APIs, IO, etc.). This enables unit testing of core logic without server dependencies and supports future migrations (e.g., Paper, Adventure, storage backends).
+
+## Decision
+Adopt Hexagonal Architecture:
+- Core module (mypoop-core): pure Java; contains domain logic and ports (interfaces) to external world. No Bukkit/Paper dependencies.
+- Plugin module (mypoop-plugin): implements adapters for Bukkit/Paper and wires the application.
+- Communication via well-defined ports; adapters translate between Bukkit types and core needs.
+
+## Consequences
+- Improved testability: core can be fully tested with JUnit and no server runtime.
+- Clear boundaries: domain code remains independent from infrastructure.
+- Slight overhead: need to define ports and adapters; initial wiring effort.
+- Future-friendly: easier migration to Paper and adoption of Adventure messaging.
+

--- a/docs/adr/adr-002-module-boundaries.md
+++ b/docs/adr/adr-002-module-boundaries.md
@@ -1,0 +1,26 @@
+# ADR 002: Module Boundaries and Dependencies
+
+## Status
+Accepted
+
+## Context
+We split the project into two Gradle modules: `mypoop-core` and `mypoop-plugin`.
+To keep the domain independent and testable, we need clear rules about what goes where and who depends on whom.
+
+## Decision
+- `mypoop-core` (domain):
+  - Contains business logic, value objects, and port interfaces.
+  - No dependencies on Bukkit/Paper or other server APIs.
+  - May depend on testing libraries for tests only (JUnit).
+- `mypoop-plugin` (infrastructure):
+  - Contains adapters implementing core ports using Bukkit/Paper APIs.
+  - Wires the application at runtime (plugin enable/disable lifecycle).
+  - Depends on `:mypoop-core`.
+- Direction of dependencies: only `mypoop-plugin` depends on `:mypoop-core`. Never the opposite.
+- Messaging and IO concerns must go behind ports. Adapters translate external types to domain types.
+
+## Consequences
+- Enforces separation of concerns and enables unit testing in core.
+- Reduces accidental coupling to Bukkit in domain logic.
+- Requires some boilerplate (ports + adapters + wiring), but pays off in maintainability and future migrations.
+

--- a/docs/adr/adr-003-migrate-to-paper.md
+++ b/docs/adr/adr-003-migrate-to-paper.md
@@ -1,7 +1,7 @@
 # ADR 003: Migrate to Paper as primary API and define support window
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 Spigot NMS and CraftBukkit internals make multi-version maintenance costly and brittle. Paper provides stronger APIs, performance, and community support. The project currently relies on ad-hoc per-version classes and reflection.
@@ -9,11 +9,19 @@ Spigot NMS and CraftBukkit internals make multi-version maintenance costly and b
 ## Decision
 - Target Paper API as the primary runtime API for the plugin.
 - Drop direct NMS dependencies in favor of Paper API wherever possible.
-- Define a support window: latest Paper major + previous minor (e.g., 1 latest LTS or last 2 releases).
+- Define a support window:
+  - Primary: latest 1.21.x (baseline for new features and mainline development).
+  - Transitional support (final multi-version series): 1.20.6 and 1.19.4.
 - For truly version-specific behavior, isolate adapters behind ports and prefer API-based feature flags; reflection only as a temporary bridge.
+- Do not introduce new dependencies (e.g., Adventure) until the refactor baseline is complete.
 
 ## Consequences
 - Simplifies maintenance; reduces breakage across versions.
 - Users on very old server versions may no longer be supported (documented in README/CHANGELOG).
-- Enables modern tooling (paperweight) if low-level hooks are required.
+- Enables modern tooling if low-level hooks are required, but we’ll avoid NMS by design.
+- Build is Gradle-only (Maven deprecation tracked in the checklist); Java toolchains will be aligned per targeted Paper version (e.g., Java 21 for 1.21.x; Java 17 for 1.20.6/1.19.4).
 
+## Implementation notes
+- Short term (during refactor): keep current 1.19.4 target while extracting ports/adapters and removing reflection where Paper API exists.
+- Post-refactor: move plugin baseline to Paper 1.21.x; provide separate build variants for 1.20.6 and 1.19.4 (no NMS), or gracefully degrade features when not available.
+- Messaging (Adventure) will be evaluated after the baseline refactor, per ADR-004.

--- a/docs/adr/adr-003-migrate-to-paper.md
+++ b/docs/adr/adr-003-migrate-to-paper.md
@@ -1,0 +1,19 @@
+# ADR 003: Migrate to Paper as primary API and define support window
+
+## Status
+Proposed
+
+## Context
+Spigot NMS and CraftBukkit internals make multi-version maintenance costly and brittle. Paper provides stronger APIs, performance, and community support. The project currently relies on ad-hoc per-version classes and reflection.
+
+## Decision
+- Target Paper API as the primary runtime API for the plugin.
+- Drop direct NMS dependencies in favor of Paper API wherever possible.
+- Define a support window: latest Paper major + previous minor (e.g., 1 latest LTS or last 2 releases).
+- For truly version-specific behavior, isolate adapters behind ports and prefer API-based feature flags; reflection only as a temporary bridge.
+
+## Consequences
+- Simplifies maintenance; reduces breakage across versions.
+- Users on very old server versions may no longer be supported (documented in README/CHANGELOG).
+- Enables modern tooling (paperweight) if low-level hooks are required.
+

--- a/docs/adr/adr-004-adventure-messaging.md
+++ b/docs/adr/adr-004-adventure-messaging.md
@@ -1,0 +1,18 @@
+# ADR 004: Adopt Adventure for unified messaging
+
+## Status
+Proposed
+
+## Context
+Current messaging uses Bukkit ChatColor, titles, and custom NMS per-version code for action bars. Adventure provides a modern, version-abstracted API for rich text, titles, action bars, and audiences.
+
+## Decision
+- Adopt Adventure (Kyori) as the standard messaging layer.
+- Create a `MessagingService` in core that composes messages via ports, backed by an Adventure-based adapter in the plugin.
+- Replace direct ChatColor usages gradually; centralize message formatting and keys.
+
+## Consequences
+- Consistent messaging across versions with less NMS.
+- Requires new dependency and adapter wiring in plugin.
+- Enables future localization and theming via message catalogs.
+

--- a/docs/adr/adr-005-multi-version-strategy.md
+++ b/docs/adr/adr-005-multi-version-strategy.md
@@ -1,0 +1,37 @@
+# ADR 005: Multi-version strategy without NMS
+
+## Status
+Accepted
+
+## Context
+Historically, multi-version support relied on per-version NMS/CraftBukkit internals and reflection. This is brittle and costly. We are migrating to Paper-first (ADR-003) and want a simple, maintainable approach that avoids NMS and extra dependencies during the refactor.
+
+## Decision
+- Support window
+  - Primary: Paper 1.21.x (baseline for new features).
+  - Transitional support (final multi-version series): 1.20.6 and 1.19.4.
+- No NMS modules for new versions; prefer Paper API capabilities and graceful degradation.
+- During refactor: keep code unified behind ports/adapters; avoid introducing new libraries (e.g., Adventure) until baseline is complete.
+- Version handling approach
+  - Prefer feature detection via API (e.g., Paper API methods/classes presence) and simple version guards when necessary.
+  - Introduce a small `VersionCapabilities` service (infrastructure) to centralize capability checks and minor behavioral differences. Expose only domain-level flags to the core.
+  - Minimize reflection; only as a short-lived bridge until a proper API path is in place.
+- Build strategy
+  - Single codebase, compileOnly against current primary Paper API.
+  - Use Java toolchains matching targets (Java 21 for 1.21.x; Java 17 for 1.20.6/1.19.4 execution). The plugin code will remain source-compatible across the support window.
+  - Validate older targets via local test runs; no shaded or per-version jars unless a hard blocker appears.
+
+## Consequences
+- Reduced maintenance overhead; no per-version NMS code.
+- Clear upgrade path: after the transitional series, we can drop 1.19.4/1.20.6 to focus on latest.
+- Minor adapter code may be needed to normalize behaviors, encapsulated in `VersionCapabilities`.
+
+## Alternatives considered
+- Per-version Gradle modules: rejected for now (adds complexity) unless hard compatibility breaks are found.
+- External multi-version libraries: postponed; the current scope avoids adding dependencies until refactor baseline is done.
+
+## Implementation notes
+- Document the support window in README and plugin.yml.
+- Add a lightweight `VersionCapabilities` and route version-specific checks through it.
+- Replace existing reflection bridge incrementally with Paper API usages guarded by capabilities.
+

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -46,3 +46,11 @@ Questo file traccia le decisioni architetturali e di processo prese durante il r
 - Confermata configurazione `.gitignore` per ignorare: `**/target/`, `**/build/`, `.gradle/`, `.idea/`, `*.iml`, `*.log`, `out/`.
 - Effetto: working tree pulito dopo build; ridotta confusione nei diff e nei branch. Nessun impatto sui sorgenti.
 - Raccomandazione: abilitare "Automatically delete head branches" su GitHub per evitare branch remoti obsoleti dopo merge.
+
+---
+
+## 2025-09-25: Prime porte e adapter (Hexagonal)
+- Introdotta porta `PlayerMessagingPort` in `:mypoop-core` (nessun import Bukkit/Paper).
+- Creato adapter `BukkitPlayerMessagingAdapter` in `:mypoop-plugin` che implementa la porta usando Bukkit API.
+- Formalizzati ADR 001 (Hexagonal) e ADR 002 (confini moduli).
+- Prossimi passi: wiring dell’adapter nel plugin bootstrap; definire ulteriori porte per I/O e comandi.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -54,3 +54,11 @@ Questo file traccia le decisioni architetturali e di processo prese durante il r
 - Creato adapter `BukkitPlayerMessagingAdapter` in `:mypoop-plugin` che implementa la porta usando Bukkit API.
 - Formalizzati ADR 001 (Hexagonal) e ADR 002 (confini moduli).
 - Prossimi passi: wiring dell’adapter nel plugin bootstrap; definire ulteriori porte per I/O e comandi.
+
+---
+
+## 2025-09-25: Porte Config/Logging, wiring e ponte temporaneo via reflection
+- Aggiunte porte `ConfigPort` e `LoggingPort` nel core; creati adapter Bukkit corrispondenti nel plugin.
+- Wiring: istanziato `BukkitPlayerMessagingAdapter` e passato a `PlayerEvents` come fallback centralizzato.
+- Decoupling: rimosse dipendenze compile-time dai moduli NMS; `PlayerEvents` istanzia classi per-versione via reflection come ponte temporaneo.
+- ADR proposti: 003 Migrazione a Paper (primary API), 004 Adozione Adventure per messaggistica unificata.

--- a/docs/refactor-checklist.md
+++ b/docs/refactor-checklist.md
@@ -28,9 +28,10 @@ Checklist viva per il refactor incrementale.
 - [ ] Definire porte e adapter minimi
   - [x] Porta PlayerMessagingPort nel core
   - [x] Adapter BukkitPlayerMessagingAdapter nel plugin
-  - [ ] Wiring: inizializzare l'adapter nel bootstrap del plugin e fornirlo ai servizi core
+  - [x] Wiring: inizializzare l'adapter nel bootstrap del plugin e fornirlo ai servizi core
   - [ ] Definire porta per configurazione (ConfigPort) e relativo adapter Bukkit/file
   - [ ] Definire porta per logging (LoggingPort) e relativo adapter Bukkit/SLF4J
+  - [ ] Sostituire reflection provvisoria con strategia definitiva (migrazione Paper + riduzione NMS / submoduli Gradle)
 - [ ] Refactor comandi (un file per comando, dispatcher)
   - [ ] Mappare comandi esistenti e output
   - [ ] Introdurre CommandDispatcher e classi per comando

--- a/docs/refactor-checklist.md
+++ b/docs/refactor-checklist.md
@@ -26,8 +26,18 @@ Checklist viva per il refactor incrementale.
   - [x] Test JUnit su PoopRulesService
   - [x] Report JaCoCo core
 - [ ] Definire porte e adapter minimi
+  - [x] Porta PlayerMessagingPort nel core
+  - [x] Adapter BukkitPlayerMessagingAdapter nel plugin
+  - [ ] Wiring: inizializzare l'adapter nel bootstrap del plugin e fornirlo ai servizi core
+  - [ ] Definire porta per configurazione (ConfigPort) e relativo adapter Bukkit/file
+  - [ ] Definire porta per logging (LoggingPort) e relativo adapter Bukkit/SLF4J
 - [ ] Refactor comandi (un file per comando, dispatcher)
+  - [ ] Mappare comandi esistenti e output
+  - [ ] Introdurre CommandDispatcher e classi per comando
+  - [ ] Delegare la logica al core (via porte)
 - [ ] Listener snelli → delega a servizi core
+  - [ ] Inventariare listener
+  - [ ] Estrarre logica > 30 righe in servizi core
 - [ ] Migrazione a Paper API (nuova ADR)
 - [ ] Introduzione Adventure + catalogo messaggi centralizzato
 - [ ] Persistenza astratta (in-memory + file)

--- a/docs/refactor-checklist.md
+++ b/docs/refactor-checklist.md
@@ -29,8 +29,8 @@ Checklist viva per il refactor incrementale.
   - [x] Porta PlayerMessagingPort nel core
   - [x] Adapter BukkitPlayerMessagingAdapter nel plugin
   - [x] Wiring: inizializzare l'adapter nel bootstrap del plugin e fornirlo ai servizi core
-  - [ ] Definire porta per configurazione (ConfigPort) e relativo adapter Bukkit/file
-  - [ ] Definire porta per logging (LoggingPort) e relativo adapter Bukkit/SLF4J
+  - [x] Definire porta per configurazione (ConfigPort) e relativo adapter Bukkit/file
+  - [x] Definire porta per logging (LoggingPort) e relativo adapter Bukkit/SLF4J
   - [ ] Sostituire reflection provvisoria con strategia definitiva (migrazione Paper + riduzione NMS / submoduli Gradle)
 - [ ] Refactor comandi (un file per comando, dispatcher)
   - [ ] Mappare comandi esistenti e output
@@ -46,3 +46,17 @@ Checklist viva per il refactor incrementale.
 - [ ] Release `v1.0.0-refactored`
 
 Aggiornare lo stato e aggiungere sotto-task man mano.
+
+## Multi-version senza NMS (transizione finale)
+- [x] ADR-003 aggiornato: finestra supporto (Primario 1.21.x; Transitorio 1.20.6, 1.19.4)
+- [x] ADR-005 aggiunto: strategia multi-version senza NMS
+- [ ] Introdurre `VersionCapabilities` lato plugin per centralizzare capability checks
+- [ ] Rimuovere i punti di reflection dove esiste una Paper API equivalente (es. action bar/titles)
+- [ ] Validare compatibilità su 1.20.6 e 1.19.4 con test manuali su server locale
+- [ ] Aggiornare README/CHANGELOG (support window, requisiti Java: 1.21.x=Java 21; 1.20.6/1.19.4=Java 17)
+
+## Rimozione Maven (progressiva)
+- [ ] Deprecare build Maven nel README
+- [ ] Rimuovere i pom.xml dei moduli legacy (VersionsInterfaces, v1_8, v1_11, v1_13, v1_19_4, MyPoopPlugin) + root pom.xml
+- [ ] Portare eventuali moduli rimasti in Gradle (solo se davvero necessari)
+- [ ] Aggiornare pipeline CI a Gradle only

--- a/mypoop-core/src/main/java/me/spighetto/mypoop/core/port/ConfigPort.java
+++ b/mypoop-core/src/main/java/me/spighetto/mypoop/core/port/ConfigPort.java
@@ -1,0 +1,22 @@
+package me.spighetto.mypoop.core.port;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Outbound port for configuration access.
+ * Implementations provide values from plugin config or other sources.
+ */
+public interface ConfigPort {
+    Optional<String> getString(String path);
+    Optional<Boolean> getBoolean(String path);
+    Optional<Integer> getInt(String path);
+    Optional<Long> getLong(String path);
+    Optional<Double> getDouble(String path);
+    default String getString(String path, String def) { return getString(path).orElse(def); }
+    default boolean getBoolean(String path, boolean def) { return getBoolean(path).orElse(def); }
+    default int getInt(String path, int def) { return getInt(path).orElse(def); }
+    default long getLong(String path, long def) { return getLong(path).orElse(def); }
+    default double getDouble(String path, double def) { return getDouble(path).orElse(def); }
+}
+

--- a/mypoop-core/src/main/java/me/spighetto/mypoop/core/port/LoggingPort.java
+++ b/mypoop-core/src/main/java/me/spighetto/mypoop/core/port/LoggingPort.java
@@ -1,0 +1,12 @@
+package me.spighetto.mypoop.core.port;
+
+/**
+ * Outbound port for logging from core/services.
+ */
+public interface LoggingPort {
+    void info(String message);
+    void warn(String message);
+    void error(String message, Throwable t);
+    default void error(String message) { error(message, null); }
+}
+

--- a/mypoop-core/src/main/java/me/spighetto/mypoop/core/port/PlayerMessagingPort.java
+++ b/mypoop-core/src/main/java/me/spighetto/mypoop/core/port/PlayerMessagingPort.java
@@ -1,0 +1,17 @@
+package me.spighetto.mypoop.core.port;
+
+import java.util.UUID;
+
+/**
+ * Outbound port for player messaging from the domain/core layer.
+ *
+ * No Bukkit/Paper types here: adapters in the plugin implement this port.
+ */
+public interface PlayerMessagingPort {
+    /**
+     * Sends a plain text message to the given player, if online.
+     * Implementations should be null-safe and no-op if the player is offline.
+     */
+    void sendTo(UUID playerId, String message);
+}
+

--- a/mypoop-plugin/build.gradle.kts
+++ b/mypoop-plugin/build.gradle.kts
@@ -27,24 +27,21 @@ dependencies {
 
     compileOnly("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
     compileOnly("javax.validation:validation-api:1.1.0.Final")
-
-    // Dipendenze locali pre-compilate (Maven non disponibile qui):
-    compileOnly(files(rootProject.file("VersionsInterfaces/target/classes")))
-    compileOnly(files(rootProject.file("v1_8/target/classes")))
-    compileOnly(files(rootProject.file("v1_11/target/classes")))
-    compileOnly(files(rootProject.file("v1_13/target/classes")))
-    compileOnly(files(rootProject.file("v1_19_4/target/classes")))
 }
 
 sourceSets {
     val main by getting {
         java.setSrcDirs(
             listOf(
+                // Sorgenti del plugin
                 rootProject.file("MyPoopPlugin/src/main/java").path,
+                // Forniamo IPoop/IMessages a compile-time
+                rootProject.file("VersionsInterfaces/src/main/java").path,
             ),
         )
         resources.setSrcDirs(
             listOf(
+                // Solo le risorse del plugin (evito duplicati di plugin.yml)
                 rootProject.file("MyPoopPlugin/src/main/resources").path,
             ),
         )
@@ -56,16 +53,10 @@ tasks.named<ProcessResources>("processResources") {
     filesMatching("plugin.yml") { expand("project" to project) }
 }
 
-// Packaging: includi classi dei moduli locali (me/**) per simulare shading
+// Packaging: solo classi del plugin (niente moduli NMS per ora)
 tasks.named<Jar>("jar") {
     archiveFileName.set("MyPoop.jar")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-    from(rootProject.file("VersionsInterfaces/target/classes")) { include("me/**") }
-    from(rootProject.file("v1_8/target/classes")) { include("me/**") }
-    from(rootProject.file("v1_11/target/classes")) { include("me/**") }
-    from(rootProject.file("v1_13/target/classes")) { include("me/**") }
-    from(rootProject.file("v1_19_4/target/classes")) { include("me/**") }
 }
 
 // ----------------------

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>v1_8</module>
         <module>v1_11</module>
         <module>v1_13</module>
+        <module>v1_19_4</module>
         <module>MyPoopPlugin</module>
     </modules>
 


### PR DESCRIPTION
Consolidate Gradle multi-module build (core, plugin, nms-interfaces, nms-v1_19_4).
Wire core ports/adapters (PlayerMessaging, Config, Logging) and bootstrap them in the plugin.
Introduce VersionCapabilities to centralize minor version differences (titles/subtitles via Bukkit API), keeping legacy reflection as fallback.
Paper-first plan documented: no new dependencies during the refactor; avoid NMS for new versions.
Repo hygiene: ignore local dev server directory (run/) to keep diffs clean.
Motivation
Reduce maintenance cost and fragility of NMS/reflection across versions.
Move towards a clean Hexagonal architecture with a testable core.
Prepare for a final multi-version transition before focusing on latest Paper.
Changes
Code:
New: mypoop/version/VersionCapabilities (no extra deps; titles/subtitles via Bukkit API).
Updated: MyPoop.java (wiring VersionCapabilities); PlayerEvents.java (use titles/subtitles when available, fallback to legacy reflection or chat).
Docs:
ADR-003 updated: Paper-first, support window defined (Primary 1.21.x; Transitional 1.20.6, 1.19.4).
ADR-005 added: multi-version strategy without NMS (single codebase, feature detection, VersionCapabilities).
Decision log, refactor checklist, and questions updated accordingly.
Repo:
.gitignore: added run/ so local dev server artifacts are never committed.