### PR TITLE
refactor: implement Command pattern with CommandDispatcher

### DIFF
--- a/MyPoopPlugin/src/main/java/me/spighetto/commands/Command.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/commands/Command.java
@@ -1,0 +1,41 @@
+package me.spighetto.commands;
+
+import org.bukkit.command.CommandSender;
+
+/**
+ * Interface for plugin commands following the Command pattern.
+ * Each command implementation handles a specific subcommand.
+ */
+public interface Command {
+
+    /**
+     * Executes the command.
+     *
+     * @param sender the command sender
+     * @param args command arguments (without the subcommand name)
+     * @return true if the command was handled, false otherwise
+     */
+    boolean execute(CommandSender sender, String[] args);
+
+    /**
+     * Gets the subcommand name that this command handles.
+     *
+     * @return the subcommand name (e.g., "reload")
+     */
+    String getName();
+
+    /**
+     * Gets the permission required to execute this command.
+     *
+     * @return the permission node, or null if no permission is required
+     */
+    String getPermission();
+
+    /**
+     * Gets the usage message for this command.
+     *
+     * @return the usage message
+     */
+    String getUsage();
+}
+

--- a/MyPoopPlugin/src/main/java/me/spighetto/commands/CommandDispatcher.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/commands/CommandDispatcher.java
@@ -1,0 +1,73 @@
+package me.spighetto.commands;
+
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Central dispatcher for MyPoop plugin commands.
+ * Implements the Command pattern for better separation of concerns.
+ */
+public class CommandDispatcher implements CommandExecutor {
+
+    private final Map<String, Command> commands = new HashMap<>();
+
+    /**
+     * Registers a command handler.
+     *
+     * @param command the command to register
+     */
+    public void registerCommand(Command command) {
+        commands.put(command.getName().toLowerCase(), command);
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull org.bukkit.command.Command cmd,
+                            @NotNull String label, @NotNull String[] args) {
+
+        if (!cmd.getName().equalsIgnoreCase("mypoop")) {
+            return false;
+        }
+
+        // No arguments provided
+        if (args.length == 0) {
+            sender.sendMessage(ChatColor.RED + "Usage: /mypoop <subcommand>");
+            sender.sendMessage(ChatColor.YELLOW + "Available subcommands:");
+            for (Command command : commands.values()) {
+                sender.sendMessage(ChatColor.YELLOW + "  - " + command.getUsage());
+            }
+            return true;
+        }
+
+        // Find and execute the subcommand
+        String subcommand = args[0].toLowerCase();
+        Command command = commands.get(subcommand);
+
+        if (command == null) {
+            sender.sendMessage(ChatColor.RED + "Unknown subcommand: " + args[0]);
+            sender.sendMessage(ChatColor.YELLOW + "Available subcommands:");
+            for (Command cmd2 : commands.values()) {
+                sender.sendMessage(ChatColor.YELLOW + "  - " + cmd2.getUsage());
+            }
+            return true;
+        }
+
+        // Check permission
+        String permission = command.getPermission();
+        if (permission != null && !sender.hasPermission(permission)) {
+            sender.sendMessage(ChatColor.RED + "You don't have permission to use this command");
+            return true;
+        }
+
+        // Execute the command (pass args without the subcommand name)
+        String[] subArgs = new String[args.length - 1];
+        System.arraycopy(args, 1, subArgs, 0, args.length - 1);
+
+        return command.execute(sender, subArgs);
+    }
+}
+

--- a/MyPoopPlugin/src/main/java/me/spighetto/commands/ReloadCommand.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/commands/ReloadCommand.java
@@ -2,62 +2,54 @@ package me.spighetto.commands;
 
 import me.spighetto.mypoop.MyPoop;
 import net.md_5.bungee.api.ChatColor;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 
-import javax.validation.constraints.NotNull;
 import java.util.logging.Level;
 
-public class Reload implements CommandExecutor{
+/**
+ * Command implementation for reloading the plugin configuration.
+ * Performs a safe reload without restarting the plugin.
+ */
+public class ReloadCommand implements Command {
 
     private final MyPoop plugin;
 
-    public Reload(MyPoop plugin) {
+    public ReloadCommand(MyPoop plugin) {
         this.plugin = plugin;
     }
 
     @Override
-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String nome, @NotNull String[] args) {
-        
-        if(!cmd.getName().equalsIgnoreCase("mypoop")) {
-            return false;
-        }
-        
-        if(args.length == 0) {
-            sender.sendMessage(ChatColor.RED + "Usage: /mypoop reload");
-            return true;
-        }
-        
-        if(!args[0].equalsIgnoreCase("reload")) {
-            sender.sendMessage(ChatColor.RED + "Unknown subcommand: " + args[0]);
-            sender.sendMessage(ChatColor.YELLOW + "Usage: /mypoop reload");
-            return true;
-        }
-        
-        // Permission check (if configured in plugin.yml)
-        if(!sender.hasPermission("mypoop.reload")) {
-            sender.sendMessage(ChatColor.RED + "You don't have permission to reload MyPoop");
-            return true;
-        }
-        
-        // Execute safe reload
+    public boolean execute(CommandSender sender, String[] args) {
         try {
             safeReload();
             sender.sendMessage(ChatColor.GREEN + "MyPoop configuration reloaded successfully");
             plugin.getLogger().info("Configuration reloaded by " + sender.getName());
-        } catch(Exception e) {
+        } catch (Exception e) {
             sender.sendMessage(ChatColor.RED + "Failed to reload MyPoop: " + e.getMessage());
             plugin.getLogger().log(Level.SEVERE, "Failed to reload plugin configuration", e);
         }
-        
         return true;
+    }
+
+    @Override
+    public String getName() {
+        return "reload";
+    }
+
+    @Override
+    public String getPermission() {
+        return "mypoop.reload";
+    }
+
+    @Override
+    public String getUsage() {
+        return "reload - Reloads the plugin configuration";
     }
 
     /**
      * Performs a safe reload without disabling/enabling the plugin.
      * Only reloads configuration and clears runtime caches.
-     * 
+     *
      * CRITICAL: Never use disablePlugin()/enablePlugin() as it causes:
      * - Memory leaks
      * - ClassLoader issues
@@ -67,15 +59,15 @@ public class Reload implements CommandExecutor{
     private void safeReload() {
         // 1. Clear existing poops
         plugin.deletePoops();
-        
+
         // 2. Clear player food levels cache
         plugin.playersLevelFood.clear();
-        
+
         // 3. Reload configuration from disk
         plugin.reloadConfig();
-        
+
         // 4. Re-parse config values into PoopConfig wrapper
         plugin.readConfigs();
     }
-
 }
+

--- a/MyPoopPlugin/src/main/java/me/spighetto/mypoop/MyPoop.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/mypoop/MyPoop.java
@@ -1,6 +1,7 @@
 package me.spighetto.mypoop;
 
-import me.spighetto.commands.Reload;
+import me.spighetto.commands.CommandDispatcher;
+import me.spighetto.commands.ReloadCommand;
 import me.spighetto.events.playerevents.PlayerEvents;
 import me.spighetto.mypoopversionsinterfaces.IPoop;
 import me.spighetto.stats.Metrics;
@@ -56,7 +57,10 @@ public final class MyPoop extends JavaPlugin {
         super.getServer().getPluginManager().registerEvents(new PlayerEvents(this, messagingPort, versionCapabilities), this);
         new Metrics(this, 8159);
 
-        Objects.requireNonNull(getCommand("mypoop")).setExecutor(new Reload(this));
+        // Setup command dispatcher
+        CommandDispatcher commandDispatcher = new CommandDispatcher();
+        commandDispatcher.registerCommand(new ReloadCommand(this));
+        Objects.requireNonNull(getCommand("mypoop")).setExecutor(commandDispatcher);
 
         if (this.getConfig().getBoolean("updateChecker")) {
             new UpdateChecker(this, 77372, "MyPoop");


### PR DESCRIPTION
## Changes
- Introduce Command interface for extensible command handling
- Implement CommandDispatcher for centralized routing
- Extract ReloadCommand from monolithic Reload class
- Remove obsolete Reload.java
## Benefits
- Better separation of concerns (SRP)
- Easier to add new commands (OCP)
- Improved testability
- Automatic help/usage generation
## Testing
- ✅ Build successful
- ✅ Checkstyle 0 warnings
- ✅ Backward compatible (same `/mypoop reload` command)
Related to roadmap: CommandDispatcher quick win