### PR TITLE
fix(1.19.4): embed MyPoop_v1_19_4 impl to fix ClassNotFound

### DIFF
--- a/MyPoopPlugin/src/main/java/me/spighetto/mypoopv1_19_4/MyPoop_v1_19_4.java
+++ b/MyPoopPlugin/src/main/java/me/spighetto/mypoopv1_19_4/MyPoop_v1_19_4.java
@@ -1,0 +1,53 @@
+package me.spighetto.mypoopv1_19_4;
+
+import me.spighetto.mypoopversionsinterfaces.IPoop;
+import org.bukkit.*;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public final class MyPoop_v1_19_4 implements IPoop {
+
+    private final Item poopItem;
+
+    public MyPoop_v1_19_4(Player player) {
+        poopItem = getCocoaBeansItem(player.getWorld(), player.getLocation());
+
+        poopItem.setPickupDelay(Integer.MAX_VALUE);
+        player.getWorld().playSound(player.getLocation(), Sound.ENTITY_SLIME_HURT, (float) 1.0, (float) 1.5);
+    }
+
+    public Item getCocoaBeansItem(World world, Location location) {
+        ItemStack cocoa = new ItemStack(Material.COCOA_BEANS);
+        ItemMeta itemMeta = cocoa.getItemMeta();
+        if(itemMeta != null) {
+            itemMeta.setCustomModelData(1);
+            cocoa.setItemMeta(itemMeta);
+        }
+        return world.dropItem(location, cocoa);
+    }
+
+    @Override
+    public void setName(String name) {
+        poopItem.setCustomNameVisible(true);
+        poopItem.setCustomName(ChatColor.translateAlternateColorCodes('&', name));
+    }
+
+    @Override
+    public void setName(String name, String colorCode) {
+        poopItem.setCustomNameVisible(true);
+        poopItem.setCustomName(ChatColor.translateAlternateColorCodes('&', name));
+    }
+
+    @Override
+    public Item getPoopItem() {
+        return poopItem;
+    }
+
+    @Override
+    public void delete() {
+        poopItem.remove();
+    }
+}
+


### PR DESCRIPTION
Embed 1.19.4 implementation into plugin sources so PoopFactory reflection can load it at runtime. Also verified fat-jar includes mypoop-core ports.\n\n- Adds MyPoopPlugin/src/main/java/me/spighetto/mypoopv1_19_4/MyPoop_v1_19_4.java\n- Confirms shaded core in plugin jar (PlayerMessagingPort present)\n- Smoke test on local Paper: no ClassNotFound/NoClassDefFound errors.